### PR TITLE
Refine DOM guards with is-kit

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "is-kit": "latest",
     "next": "15.4.7",
     "next-head-seo": "^0.1.3",
     "react": "19.0.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "is-kit": "latest",
+    "is-kit": "^1.0.1",
     "next": "15.4.7",
     "next-head-seo": "^0.1.3",
     "react": "19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
 
   .:
     dependencies:
+      is-kit:
+        specifier: ^1.0.1
+        version: 1.0.1
       next:
         specifier: 15.4.7
         version: 15.4.7(@babel/core@7.26.10)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -4070,6 +4073,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-kit@1.0.1:
+    resolution: {integrity: sha512-9OCs6DQI/W1q9WqmD9S/L8k/yCG7PWzaxX+zi0CB2IKdIvUQJ0QZhWJgW2ZKc91Sx8uGPUyBm5oWE9PskbH0aQ==}
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
@@ -10897,6 +10903,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-kit@1.0.1: {}
 
   is-map@2.0.3: {}
 

--- a/src/components/molecules/TsParticles.tsx
+++ b/src/components/molecules/TsParticles.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-call */
 import { type Container as ParticleContainer, type ISourceOptions } from '@tsparticles/engine';
 import Particles, { initParticlesEngine } from '@tsparticles/react';
 import { loadSlim } from '@tsparticles/slim';

--- a/src/hooks/useFadeIn.ts
+++ b/src/hooks/useFadeIn.ts
@@ -1,3 +1,4 @@
+import { isBrowser } from 'is-kit';
 import { useEffect } from 'react';
 
 import { fadeInSetting } from '@/lib/fade-in';
@@ -6,7 +7,15 @@ import type { Dispatch, SetStateAction } from 'react';
 
 export const useFadeIn = (targetId: string, setter: Dispatch<SetStateAction<string>>) => {
   useEffect(() => {
+    if (!isBrowser()) {
+      return;
+    }
+
     const listenEvent = fadeInSetting(targetId, setter);
+
+    if (!listenEvent) {
+      return;
+    }
 
     window.addEventListener('scroll', listenEvent);
     return () => {

--- a/src/lib/fade-in.ts
+++ b/src/lib/fade-in.ts
@@ -1,12 +1,22 @@
+import { isBrowser, isElement } from 'is-kit';
 import { Dispatch, SetStateAction } from 'react';
 
-export const fadeInSetting = (targetId: string, setter: Dispatch<SetStateAction<string>>) => {
-  const element = typeof window === 'object' ? document.getElementById(targetId) : null;
+export const fadeInSetting = (
+  targetId: string,
+  setter: Dispatch<SetStateAction<string>>,
+): (() => void) | undefined => {
+  if (!isBrowser()) {
+    return undefined;
+  }
 
   const listenScrollEvent = () => {
-    const featureTitleScrollPosition = element
-      ? element.getBoundingClientRect().top + window.scrollY
-      : 0;
+    const element = document.getElementById(targetId);
+
+    if (!isElement(element)) {
+      return;
+    }
+
+    const featureTitleScrollPosition = element.getBoundingClientRect().top + window.scrollY;
 
     if (window.scrollY > featureTitleScrollPosition - 1400) {
       setter('fadein-after');

--- a/src/lib/type-writer.ts
+++ b/src/lib/type-writer.ts
@@ -1,3 +1,5 @@
+import { isBrowser, isElement } from 'is-kit';
+
 type TypeWriter = {
   element: string;
   speed: number;
@@ -5,16 +7,16 @@ type TypeWriter = {
 };
 
 export const typeWriter = (param: TypeWriter) => {
-  if (typeof window === 'object') {
-    const element = document?.querySelector(param.element);
-    const { speed, string } = param;
+  if (!isBrowser()) return;
 
-    if (element) {
-      string.split('').forEach((char, index) => {
-        setTimeout(() => {
-          element.textContent += char;
-        }, speed * index);
-      });
-    }
-  }
+  const element = document.querySelector(param.element);
+  const { speed, string } = param;
+
+  if (!isElement(element)) return;
+
+  string.split('').forEach((char, index) => {
+    setTimeout(() => {
+      element.textContent += char;
+    }, speed * index);
+  });
 };

--- a/src/types/is-kit.d.ts
+++ b/src/types/is-kit.d.ts
@@ -1,0 +1,4 @@
+declare module 'is-kit' {
+  export function isBrowser(): boolean;
+  export function isElement(value: unknown): value is Element;
+}


### PR DESCRIPTION
## Summary
- guard the fade-in hook with `is-kit` so scroll listeners only attach in the browser
- refresh the type-writer helper to call `is-kit` directly and avoid redundant wrappers
- update the local `is-kit` type declarations to mirror the package exports

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ea3032a514832d9560977220b610bb